### PR TITLE
Added page container

### DIFF
--- a/app/components/Container.tsx
+++ b/app/components/Container.tsx
@@ -1,0 +1,15 @@
+type ContainerProps = {
+  title?: string
+  children: React.ReactNode
+}
+
+const Container: React.FC<ContainerProps> = ({ title, children }) : React.ReactElement => {
+  return (
+    <div className="container mx-auto px-4 py-16 sm:px-6 lg:px-8">
+      {title && <h2 className="text-3xl text-gray-900">{title}</h2>}
+      {children}
+    </div>
+  );
+};
+
+export default Container;


### PR DESCRIPTION
**Change**

- Added a Container component for pages to be used along side the Navigation component.
- The component accepts a optional title and required children components to build out the rest of the page.

**Purpose**

The Container component is used to keep paddings and margins, and any responsive values consistent across pages