### PR TITLE
Added a InfoCard component for dashboards

### DIFF
--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -1,0 +1,15 @@
+import { Card } from "flowbite-react";
+
+type InfoCardProps = {
+  title: string
+  value: string
+}
+
+const InfoCard: React.FC<InfoCardProps> = ({ title, value }) : React.ReactElement => {
+  return <Card>
+        <h5 className="font-bold text-primary">{title}</h5>
+        <p className="text-2xl">{value}</p>
+    </Card>
+}
+
+export default InfoCard


### PR DESCRIPTION
**What**

- Added a new InfoCard component for display on Dashboards

**Purpose**

- InfoCard is used to display stats to users when visiting the dashboard.