### PR TITLE
Added a date range selector component

### DIFF
--- a/app/components/DateSelector.tsx
+++ b/app/components/DateSelector.tsx
@@ -1,0 +1,27 @@
+"use client"
+import React, { useState } from "react"
+import { Datepicker } from "flowbite-react";
+import { Label } from "flowbite-react";
+import { addDays } from "date-fns";
+
+type DateSelectorProps = {
+  fromDate: Date;
+  toDate: Date;
+  setFromDate: (date: Date) => void;
+  setToDate: (date: Date) => void;
+}
+
+const DateSelector: React.FC<DateSelectorProps> = ({ fromDate, toDate, setFromDate, setToDate }) : React.ReactElement => {
+  return <div className="flex gap-4 items-center justify-end">
+        <div className="flex flex-col">
+            <Label>From</Label>
+            <Datepicker onSelectedDateChanged={(date: Date) => setFromDate(date)} defaultDate={fromDate} />
+        </div>
+        <div className="flex flex-col">
+            <Label>To</Label>
+            <Datepicker onSelectedDateChanged={(date: Date) => setToDate(date)} minDate={addDays(fromDate, 1)} defaultDate={toDate} />
+        </div>
+  </div>
+}
+
+export default DateSelector

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "date-fns": "^3.6.0",
     "flowbite-react": "^0.10.1",
     "next": "14.2.5",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       flowbite-react:
         specifier: ^0.10.1
         version: 0.10.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.7)
@@ -458,6 +461,9 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   debounce@2.1.0:
     resolution: {integrity: sha512-OkL3+0pPWCqoBc/nhO9u6TIQNTK44fnBnzuVtJAbp13Naxw9R6u21x+8tVTka87AhDZ3htqZ2pSSsZl9fqL2Wg==}
@@ -2014,6 +2020,8 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
+
+  date-fns@3.6.0: {}
 
   debounce@2.1.0: {}
 


### PR DESCRIPTION
**What**

- Added a range selector composed of two [Flowbite Datepicker](https://flowbite-react.com/docs/components/datepicker)
- Added [date fns](https://date-fns.org/) package for faster date calculations.

**Purpose**

- Allows the user to select a range of dates and set those dates for the parent.
- Additional, when the from date gets updated, the min date for the to date is update to be 1 day ahead.